### PR TITLE
Add inactive pod cleanup

### DIFF
--- a/api/src/pods/orchestrator.ts
+++ b/api/src/pods/orchestrator.ts
@@ -204,6 +204,9 @@ export class PodOrchestrator {
       // Create owner-key secret first (required for pod to mount)
       await this.createOwnerKeySecret(opts);
 
+      // Create per-pod RBAC so auth-proxy can update its own last-used annotation.
+      await this.createPodActivityRbac(opts.podId);
+
       const skillsConfigMapName = opts.skills?.length ? this.getWorkspaceSkillsConfigMapName(opts.podId) : undefined;
 
       if (skillsConfigMapName) {
@@ -309,9 +312,11 @@ export class PodOrchestrator {
           'prometheus.io/port': '3001',
           'prometheus.io/path': '/metrics',
           'owner-key-id': opts.ownerKeyId,
+          'web-os.io/last-used-at': new Date().toISOString(),
         },
       },
       spec: {
+        serviceAccountName: podName,
         restartPolicy: 'OnFailure',
         securityContext: {
           runAsUser: 1000,
@@ -358,6 +363,8 @@ export class PodOrchestrator {
               { name: 'OWNER_PUBLIC_KEY_PEM_FILE', value: '/secrets/owner/public-key.pem' },
               { name: 'DOMAIN', value: this.baseDomain },
               { name: 'WORKSPACE_PATH', value: '/workspace' },
+              { name: 'POD_NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
+              { name: 'POD_NAMESPACE', valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } } },
             ],
             volumeMounts: [
               { name: 'workspace', mountPath: '/workspace', readOnly: false },
@@ -443,6 +450,95 @@ export class PodOrchestrator {
 
     await core.createNamespacedSecret({ namespace: this.namespace, body: secret });
     console.log(`Created secret ${opts.ownerKeySecretName} for owner ${opts.ownerWallet}`);
+  }
+
+  /**
+   * Creates per-pod RBAC that allows the auth-proxy to patch only its own Pod.
+   */
+  async createPodActivityRbac(podId: string): Promise<void> {
+    if (!isKubernetesAvailable()) {
+      return;
+    }
+
+    const { core, objects } = getKubernetesClient();
+    const podName = `pod-${podId.slice(0, 8)}`;
+
+    try {
+      await core.readNamespacedServiceAccount({ namespace: this.namespace, name: podName });
+    } catch {
+      await core.createNamespacedServiceAccount({
+        namespace: this.namespace,
+        body: {
+          apiVersion: 'v1',
+          kind: 'ServiceAccount',
+          metadata: {
+            name: podName,
+            namespace: this.namespace,
+            labels: {
+              'app.kubernetes.io/name': 'web-os-user-pod-activity',
+              'app.kubernetes.io/part-of': 'web-os',
+              'pod-id': podId.slice(0, 8),
+            },
+          },
+        },
+      });
+    }
+
+    const role = {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        name: podName,
+        namespace: this.namespace,
+        labels: {
+          'app.kubernetes.io/name': 'web-os-user-pod-activity',
+          'app.kubernetes.io/part-of': 'web-os',
+          'pod-id': podId.slice(0, 8),
+        },
+      },
+      rules: [{
+        apiGroups: [''],
+        resources: ['pods'],
+        resourceNames: [podName],
+        verbs: ['get', 'patch'],
+      }],
+    };
+
+    const roleBinding = {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'RoleBinding',
+      metadata: {
+        name: podName,
+        namespace: this.namespace,
+        labels: {
+          'app.kubernetes.io/name': 'web-os-user-pod-activity',
+          'app.kubernetes.io/part-of': 'web-os',
+          'pod-id': podId.slice(0, 8),
+        },
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: podName,
+        namespace: this.namespace,
+      }],
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: podName,
+      },
+    };
+
+    await this.createObjectIfMissing(objects, role);
+    await this.createObjectIfMissing(objects, roleBinding);
+  }
+
+  private async createObjectIfMissing(objects: ReturnType<typeof getKubernetesClient>['objects'], body: any): Promise<void> {
+    try {
+      await objects.read(body);
+      return;
+    } catch {
+      await objects.create(body);
+    }
   }
 
   /**
@@ -577,6 +673,25 @@ export class PodOrchestrator {
       // Delete workspace skills ConfigMap when present
       try {
         await core.deleteNamespacedConfigMap({ name: this.getWorkspaceSkillsConfigMapName(podId), namespace: this.namespace });
+      } catch { /* ignore */ }
+
+      // Delete per-pod activity RBAC
+      try {
+        await core.deleteNamespacedServiceAccount({ name: podName, namespace: this.namespace });
+      } catch { /* ignore */ }
+      try {
+        await getKubernetesClient().objects.delete({
+          apiVersion: 'rbac.authorization.k8s.io/v1',
+          kind: 'RoleBinding',
+          metadata: { name: podName, namespace: this.namespace },
+        });
+      } catch { /* ignore */ }
+      try {
+        await getKubernetesClient().objects.delete({
+          apiVersion: 'rbac.authorization.k8s.io/v1',
+          kind: 'Role',
+          metadata: { name: podName, namespace: this.namespace },
+        });
       } catch { /* ignore */ }
 
       // Delete Pod

--- a/auth-proxy/src/index.ts
+++ b/auth-proxy/src/index.ts
@@ -67,6 +67,10 @@ const OWNER_PUBLIC_KEY_PEM_FILE = process.env.OWNER_PUBLIC_KEY_PEM_FILE || '/sec
 const SESSION_SECRET = process.env.SESSION_SECRET || 'web-os-session';
 const SESSION_DURATION_HOURS = parseInt(process.env.SESSION_DURATION_HOURS || '24');
 const DOMAIN = process.env.DOMAIN || 'pods.permaweb.run';
+const POD_NAME = process.env.POD_NAME || '';
+const POD_NAMESPACE = process.env.POD_NAMESPACE || 'web-os';
+const ACTIVITY_ANNOTATION = 'web-os.io/last-used-at';
+const ACTIVITY_UPDATE_INTERVAL_MS = parseInt(process.env.ACTIVITY_UPDATE_INTERVAL_MS || '300000', 10);
 
 import { readFileSync, existsSync } from 'fs';
 
@@ -441,7 +445,72 @@ async function handleAuthVerify(req: http.IncomingMessage, res: http.ServerRespo
   });
 }
 
+let lastActivityUpdateMs = 0;
+
+function markPodActivity(): void {
+  const now = Date.now();
+  if (!POD_NAME || now - lastActivityUpdateMs < ACTIVITY_UPDATE_INTERVAL_MS) {
+    return;
+  }
+
+  lastActivityUpdateMs = now;
+  patchPodActivity(new Date(now).toISOString()).catch((err) => {
+    console.warn('Failed to update pod activity annotation:', err instanceof Error ? err.message : err);
+  });
+}
+
+async function patchPodActivity(timestamp: string): Promise<void> {
+  const tokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+  const caPath = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
+  const host = process.env.KUBERNETES_SERVICE_HOST;
+  const port = process.env.KUBERNETES_SERVICE_PORT || '443';
+
+  if (!host || !existsSync(tokenPath)) {
+    return;
+  }
+
+  const token = readFileSync(tokenPath, 'utf-8').trim();
+  const ca = existsSync(caPath) ? readFileSync(caPath) : undefined;
+  const body = JSON.stringify({
+    metadata: {
+      annotations: {
+        [ACTIVITY_ANNOTATION]: timestamp,
+      },
+    },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const req = https.request({
+      hostname: host,
+      port,
+      method: 'PATCH',
+      path: `/api/v1/namespaces/${encodeURIComponent(POD_NAMESPACE)}/pods/${encodeURIComponent(POD_NAME)}`,
+      ca,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/merge-patch+json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    }, (res) => {
+      let responseBody = '';
+      res.on('data', chunk => responseBody += chunk.toString());
+      res.on('end', () => {
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+          resolve();
+        } else {
+          reject(new Error(`Kubernetes API returned ${res.statusCode}: ${responseBody}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
 async function proxyRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  markPodActivity();
   const options = {
     hostname: 'localhost',
     port: BACKEND_PORT,

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -161,6 +161,16 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
+    # Allow Kubernetes API access for auth-proxy to patch its own last-used annotation.
+    # RBAC limits each pod service account to get/patch only its own Pod.
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
     # Allow egress to external LLM APIs only
     # Blocks internal cluster access for security
     - to:

--- a/k8s/stale-pod-cleanup.yaml
+++ b/k8s/stale-pod-cleanup.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stale-pod-cleanup
+  namespace: web-os
+  labels:
+    app.kubernetes.io/name: stale-pod-cleanup
+    app.kubernetes.io/part-of: web-os
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: stale-pod-cleanup
+  namespace: web-os
+  labels:
+    app.kubernetes.io/name: stale-pod-cleanup
+    app.kubernetes.io/part-of: web-os
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "serviceaccounts"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: stale-pod-cleanup
+  namespace: web-os
+  labels:
+    app.kubernetes.io/name: stale-pod-cleanup
+    app.kubernetes.io/part-of: web-os
+subjects:
+  - kind: ServiceAccount
+    name: stale-pod-cleanup
+    namespace: web-os
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: stale-pod-cleanup
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: stale-pod-cleanup
+  namespace: web-os
+  labels:
+    app.kubernetes.io/name: stale-pod-cleanup
+    app.kubernetes.io/part-of: web-os
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: stale-pod-cleanup
+            app.kubernetes.io/part-of: web-os
+        spec:
+          serviceAccountName: stale-pod-cleanup
+          restartPolicy: OnFailure
+          containers:
+            - name: cleanup
+              image: bitnami/kubectl:1.35
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: NAMESPACE
+                  value: web-os
+                - name: IDLE_TTL_HOURS
+                  value: "24"
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  cutoff_epoch="$(date -u -d "${IDLE_TTL_HOURS} hours ago" +%s)"
+                  kubectl get pods -n "${NAMESPACE}" \
+                    -l app.kubernetes.io/name=web-os-user-pod \
+                    -o 'go-template={{range .items}}{{.metadata.name}}|{{.metadata.creationTimestamp}}|{{index .metadata.annotations "web-os.io/last-used-at"}}{{"\n"}}{{end}}' |
+                  while IFS='|' read -r pod_name created_at last_used_at; do
+                    [ -n "${pod_name}" ] || continue
+                    timestamp="${last_used_at:-$created_at}"
+                    timestamp_epoch="$(date -u -d "${timestamp}" +%s 2>/dev/null || echo 0)"
+
+                    if [ "${timestamp_epoch}" -gt 0 ] && [ "${timestamp_epoch}" -lt "${cutoff_epoch}" ]; then
+                      echo "Deleting stale user pod ${pod_name}; last_used_at=${timestamp}; ttl_hours=${IDLE_TTL_HOURS}"
+                      kubectl delete pod "${pod_name}" -n "${NAMESPACE}" --ignore-not-found=true
+                      kubectl delete service "${pod_name}" -n "${NAMESPACE}" --ignore-not-found=true
+                      kubectl delete ingress "${pod_name}" -n "${NAMESPACE}" --ignore-not-found=true
+                      kubectl delete configmap "${pod_name}-skills" -n "${NAMESPACE}" --ignore-not-found=true
+                      kubectl delete rolebinding "${pod_name}" -n "${NAMESPACE}" --ignore-not-found=true
+                      kubectl delete role "${pod_name}" -n "${NAMESPACE}" --ignore-not-found=true
+                      kubectl delete serviceaccount "${pod_name}" -n "${NAMESPACE}" --ignore-not-found=true
+                    fi
+                  done

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -296,10 +296,12 @@ apply_manifests() {
   
   local manifests=(
     "namespace.yaml"
+    "rbac.yaml"
     "api-deployment.yaml"
     "api-service.yaml"
     "api-hpa.yaml"
     "servicemonitor.yaml"
+    "stale-pod-cleanup.yaml"
   )
   
   for manifest in "${manifests[@]}"; do

--- a/tests/stale-pod-cleanup.test.js
+++ b/tests/stale-pod-cleanup.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const test = require('node:test');
+
+const manifest = readFileSync('k8s/stale-pod-cleanup.yaml', 'utf8');
+const deployScript = readFileSync('scripts/deploy.sh', 'utf8');
+const orchestrator = readFileSync('api/src/pods/orchestrator.ts', 'utf8');
+const authProxy = readFileSync('auth-proxy/src/index.ts', 'utf8');
+
+test('stale pod cleanup cronjob is source-controlled and scheduled hourly', () => {
+  assert.match(manifest, /kind:\s*CronJob/);
+  assert.match(manifest, /name:\s*stale-pod-cleanup/);
+  assert.match(manifest, /schedule:\s*"0 \* \* \* \*"/);
+  assert.match(manifest, /IDLE_TTL_HOURS[\s\S]*value:\s*"24"/);
+});
+
+test('cleanup job deletes pod runtime resources but preserves PVCs', () => {
+  for (const resource of ['pod', 'service', 'ingress', 'configmap', 'rolebinding', 'role', 'serviceaccount']) {
+    assert.match(manifest, new RegExp(`kubectl delete ${resource}`));
+  }
+
+  assert.doesNotMatch(manifest, /delete\s+(persistentvolumeclaim|pvc)\b/i);
+});
+
+test('cleanup manifest is included in standard deploy flow', () => {
+  assert.match(deployScript, /stale-pod-cleanup\.yaml/);
+});
+
+test('user pods are annotated and granted own-pod activity RBAC', () => {
+  assert.match(orchestrator, /web-os\.io\/last-used-at/);
+  assert.match(orchestrator, /serviceAccountName:\s*podName/);
+  assert.match(orchestrator, /resourceNames:\s*\[podName\]/);
+  assert.match(orchestrator, /verbs:\s*\['get', 'patch'\]/);
+});
+
+test('auth proxy patches last-used annotation before proxying traffic', () => {
+  assert.match(authProxy, /ACTIVITY_ANNOTATION\s*=\s*'web-os\.io\/last-used-at'/);
+  assert.match(authProxy, /method:\s*'PATCH'/);
+  assert.match(authProxy, /application\/merge-patch\+json/);
+  assert.match(authProxy, /markPodActivity\(\);/);
+});


### PR DESCRIPTION
## Summary\n- closes #8\n- records user pod activity via auth-proxy by patching `web-os.io/last-used-at` on the Pod\n- creates per-pod RBAC so each auth-proxy can only get/patch its own Pod\n- adds a source-controlled hourly CronJob to delete pods idle for more than 24 hours plus matching Service, Ingress, skills ConfigMap, and per-pod RBAC\n- keeps PVCs/workspaces intact\n- includes cleanup manifest in the deploy flow\n\n## Tests\n- `npm run build --prefix auth-proxy`\n- `npm test --prefix api`\n- `node --test tests/stale-pod-cleanup.test.js`\n- `kubectl apply --dry-run=server -f k8s/stale-pod-cleanup.yaml`